### PR TITLE
make default GPU

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   # uncomment the corresponding line for your specific CUDA version
   - nvidia::cudatoolkit # for cuda >= 11
   # - pytorch::cudatoolkit # for cuda < 11
-  - pytorch::cpuonly
+  # - pytorch::cpuonly
   - python=3.8
   - pytorch::pytorch
   - rdkit


### PR DESCRIPTION
## Description
This PR removes the cpuonly specification from the pytorch dependency, since we want the default to use GPUs

## Example / Current workflow
CPU only

## Bugfix / Desired workflow
GPU default

## Questions
N/A

## Relevant issues
N/A

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
- [x] **ready to go?**
